### PR TITLE
ci(gha): extract version bump and tagging into reusable scripts

### DIFF
--- a/.github/scripts/_common.bash
+++ b/.github/scripts/_common.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+common::check_env() {
+  local var=$1
+  [[ -z "${!var:-}" ]] && { printf 'Missing env var: %s\n' "$var" >&2; exit 1; }
+}

--- a/.github/scripts/bump-cargo.bash
+++ b/.github/scripts/bump-cargo.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "${BASH_SOURCE%/*}/_common.bash"
+
+common::check_env NEW_VERSION
+
+# Update Cargo.toml
+sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" Cargo.toml
+
+# Update Cargo.lock
+awk -v new_version="$NEW_VERSION" '
+  $0 == "[[package]]" { in_package = 1; print; next }
+  in_package && /^name = "af"/ { found_af = 1; print; next }
+  in_package && found_af && /^version = / {
+    print "version = \"" new_version "\""
+    in_package = 0; found_af = 0
+    next
+  }
+  { print }
+' Cargo.lock > Cargo.lock.tmp && mv Cargo.lock.tmp Cargo.lock

--- a/.github/scripts/commit-tag-version.bash
+++ b/.github/scripts/commit-tag-version.bash
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "${BASH_SOURCE%/*}/_common.bash"
+
+common::check_env GITHUB_REPOSITORY
+common::check_env GITHUB_REF_NAME
+common::check_env NEW_TAG
+
+# Prepare --field flags for each changed file
+files=()
+while IFS= read -r f; do
+  files+=(--field "files[][path]=$f")
+  files+=(--field "files[][contents]=$(base64 -w0 "$f")")
+done < <(git status --porcelain | awk '{print $2}')
+
+# Commit changes
+new_sha=$(
+  gh api graphql \
+    --jq '.data.createCommitOnBranch.commit.oid' \
+    --field 'query=@.github/api/queries/createCommit.graphql' \
+    --field "githubRepository=$GITHUB_REPOSITORY" \
+    --field "branchName=$GITHUB_REF_NAME" \
+    --field "expectedHeadOid=$(git rev-parse HEAD)" \
+    --field "commitMessage=$NEW_TAG" \
+    "${files[@]}"
+)
+
+# Create a new tag
+gh api graphql \
+  --field 'query=@.github/api/queries/createRef.graphql' \
+  --field "repoId=$(gh repo view "$GITHUB_REPOSITORY" --json id --jq .id)" \
+  --field "name=refs/tags/$NEW_TAG" \
+  --field "sha=$new_sha"

--- a/.github/scripts/debug-shell.bash
+++ b/.github/scripts/debug-shell.bash
@@ -2,10 +2,9 @@
 
 set -euo pipefail
 
-if [[ -z "${TUNSHELL_SECRET:-}" ]]; then
-  printf 'Missing env var: TUNSHELL_SECRET\n' >&2
-  exit 1
-fi
+source "${BASH_SOURCE%/*}/_common.bash"
+
+common::check_env TUNSHELL_SECRET
 
 url_init="${URL_INIT:-https://lets.tunshell.com/init.sh}"
 tunshell_relay="${TUNSHELL_RELAY:-eu.relay.tunshell.com}"

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -52,49 +52,10 @@ jobs:
     - name: "Bump version in Cargo.toml"
       env:
         NEW_VERSION: ${{ steps.next-version.outputs.new_version }}
-      run: |
-        # Update Cargo.toml
-        sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" Cargo.toml
-        
-        # Update Cargo.lock
-        awk -v new_version="$NEW_VERSION" '
-          $0 == "[[package]]" { in_package = 1; print; next }
-          in_package && /^name = "af"/ { found_af = 1; print; next }
-          in_package && found_af && /^version = / {
-            print "version = \"" new_version "\""
-            in_package = 0; found_af = 0
-            next
-          }
-          { print }
-        ' Cargo.lock > Cargo.lock.tmp && mv Cargo.lock.tmp Cargo.lock
+      run: .github/scripts/bump-cargo.bash
 
     - name: "Commit and tag new version"
       env:
         NEW_TAG: ${{ steps.next-version.outputs.new_tag }}
         GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
-      run: |
-        # Prepare --field flags for each changed file
-        files=()
-        for f in $(git status --porcelain | awk '{print $2}'); do
-          files+=(--field "files[][path]=$f")
-          files+=(--field "files[][contents]=$(base64 -w0 "$f")")
-        done
-
-        # Commit changes
-        new_sha="$(
-          gh api graphql \
-            --jq '.data.createCommitOnBranch.commit.oid' \
-            --field 'query=@.github/api/queries/createCommit.graphql' \
-            --field "githubRepository=$GITHUB_REPOSITORY" \
-            --field "branchName=$GITHUB_REF_NAME" \
-            --field "expectedHeadOid=$(git rev-parse HEAD)" \
-            --field "commitMessage=$NEW_TAG" \
-            "${files[@]}"
-        )"
-        
-        # Create a new tag
-        gh api graphql \
-          --field 'query=@.github/api/queries/createRef.graphql' \
-          --field "repoId=$(gh repo view "$GITHUB_REPOSITORY" --json id --jq .id)" \
-          --field "name=refs/tags/$NEW_TAG" \
-          --field "sha=$new_sha"
+      run: .github/scripts/commit-tag-version.bash


### PR DESCRIPTION
- Added standalone scripts for bumping Cargo version and tagging Git commits
- Shared env var check moved to a common helper
- Reduced duplication in workflow by calling reusable shell scripts