### PR TITLE
chore(ci/gha): simplify release job and unify artifact attestation

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -173,12 +173,6 @@ jobs:
         path: ${{ steps.add-suffix.outputs.binary_path }}
         if-no-files-found: error
 
-    - name: "Generate ${{ matrix.name }} artifact attestation"
-      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
-      with:
-        subject-name: ${{ env.PROJECT_NAME }}-${{ matrix.name }}
-        subject-digest: sha256:${{ steps.upload-artifacts.outputs.artifact-digest }}
-
     ################################# DEBUG #################################
 
     - name: "Initialize Debug Shell"
@@ -191,17 +185,12 @@ jobs:
   #                             UPLOAD ARTIFACTS                              #
   #############################################################################
 
-  upload-artifacts:
+  release:
     runs-on: ubuntu-24.04
 
     needs:
     - bump-version
-    - define-matrix
     - build
-
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
 
     steps:
     - name: "Generate GitHub App Token"
@@ -211,18 +200,30 @@ jobs:
         app-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-    - name: "Get ${{ matrix.name }} binary"
-      id: binary
+    - name: "Get macos-arm64 binary"
+      id: binary-macos-arm64
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
-        name: ${{ env.PROJECT_NAME }}-${{ matrix.name }}
-        path: dist/${{ matrix.name }}
+        name: ${{ env.PROJECT_NAME }}-macos-arm64
+        path: dist
+
+    - name: "Get macos-amd64 binary"
+      id: binary-macos-amd64
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+      with:
+        name: ${{ env.PROJECT_NAME }}-macos-amd64
+        path: dist
+
+    - name: "Generate artifacts attestation"
+      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+      with:
+        subject-path: dist/${{ env.PROJECT_NAME}}-*
 
     - name: "Add ${{ matrix.name }} artifacts to the release"
       uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
       with:
         tag_name: ${{ needs.bump-version.outputs.new-tag }}
         token: ${{ steps.github-app-token.outputs.token }}
-        files: ${{ steps.binary.outputs.download-path }}/*
+        files: dist/${{ env.PROJECT_NAME}}-*
         make_latest: true
         generate_release_notes: true


### PR DESCRIPTION
Remove per-target attestation logic and switch to a single `release` job that downloads all artifacts, generates a single attestation using subject-path, and uploads them to the release.