### PR TITLE
chore(ci/gha): move required permissions to release job and cleanup build

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -114,10 +114,6 @@ jobs:
   build:
     runs-on: ${{ matrix.runner }}
 
-    permissions:
-      id-token: write # necessary for generating artifact attestations
-      attestations: write # necessary for generating artifact attestations
-
     needs:
     - bump-version
     - define-matrix
@@ -192,14 +188,11 @@ jobs:
     - bump-version
     - build
 
-    steps:
-    - name: "Generate GitHub App Token"
-      id: github-app-token
-      uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
-      with:
-        app-id: ${{ secrets.APP_ID }}
-        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+    permissions:
+      id-token: write # necessary for generating artifact attestations
+      attestations: write # necessary for generating artifact attestations
 
+    steps:
     - name: "Get macos-arm64 binary"
       id: binary-macos-arm64
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -218,6 +211,13 @@ jobs:
       uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
       with:
         subject-path: dist/${{ env.PROJECT_NAME}}-*
+
+    - name: "Generate GitHub App Token"
+      id: github-app-token
+      uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
     - name: "Add ${{ matrix.name }} artifacts to the release"
       uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1


### PR DESCRIPTION
Move `id-token` and `attestations` permissions from the `build` job to the `release` job, which actually handles attestation generation. This aligns with GitHub's least-privilege principle.