### PR TITLE
chore(ci): add merge_group trigger to test workflow and improve Renovate

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,8 @@ on:
     branches: ["master"]
     paths: ["src", "Cargo.*"]
 
+  merge_group: {}
+
   workflow_dispatch: {}
 
 permissions:

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,19 @@
     ":gitSignOff",
     ":label(dependencies)",
     ":semanticCommitTypeAll(chore)"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
- Enable `merge_group` trigger for `test.yaml` to support GitHub merge queue.
- Enhance `renovate.json` with lock file maintenance and automerge for non-major updates.