### PR TITLE
chore(ci): add scheduled version check and support workflow_call for bump-and-build

### DIFF
--- a/.github/workflows/bump-and-build.yaml
+++ b/.github/workflows/bump-and-build.yaml
@@ -1,6 +1,7 @@
 name: "Bump and Build"
 
 on:
+  workflow_call: {}
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,8 @@ name: "Release"
 
 on:
   push:
-    tags: ["v*.*.*"]
+    tags:
+    - "v*.*.*"
 
 permissions: {}
 

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -1,0 +1,55 @@
+name: "Scheduled Version Check"
+
+on:
+  schedule:
+  - cron: "0 1 * * *"
+
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+
+  ##############################################################################
+  #                                SHOULD BUMP                                 #
+  ##############################################################################
+
+  should-bump:
+    runs-on: ubuntu-24.04
+
+    outputs:
+      bump: ${{ steps.should-bump.outputs }}
+
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: "Generate GitHub App Token"
+      id: github-app-token
+      uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+    - name: "Define if version should be bumped"
+      id: should-bump
+      env:
+        GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
+      run: |
+        last_tag="$(gh api repos/:owner/:repo/tags --paginate --jq '.[0].name')"
+        if ! git diff --quiet "$last_tag...HEAD" -- src Cargo.toml Cargo.lock; then
+          echo "true" >> "$GITHUB_OUTPUT"
+        fi
+
+  ##############################################################################
+  #                            CALL BUMP AND BUILD                             #
+  ##############################################################################
+
+  call-bump-and-build:
+    needs: should-bump
+    if: needs.should-bump.outputs.bump == 'true'
+    uses: .github/workflows/bump-and-build.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,12 +2,18 @@ name: "Tests"
 
 on:
   pull_request:
-    branches: ["master"]
-    paths: ["src", "Cargo.*"]
+    branches:
+    - "master"
+    paths:
+    - "src"
+    - "Cargo.*"
 
   push:
-    branches: ["master"]
-    paths: ["src", "Cargo.*"]
+    branches:
+    - "master"
+    paths:
+    - "src"
+    - "Cargo.*"
 
   merge_group: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "prHourlyLimit": 15,
   "extends": [
     "config:best-practices",
-    ":automergeDisabled",
     ":gitSignOff",
     ":label(dependencies)",
     ":semanticCommitTypeAll(chore)"


### PR DESCRIPTION
- Add a scheduled workflow to check if version bump is needed
- Enable calling bump-and-build via workflow_call
- Fix YAML formatting in test and release workflows
- Allow Renovate to automerge non-major updates by removing automergeDisabled