### PR TITLE
chore(ci): fix commit script and improve clean::gen::docs task

### DIFF
--- a/.github/scripts/commit-tag-version.bash
+++ b/.github/scripts/commit-tag-version.bash
@@ -8,12 +8,11 @@ common::check_env GITHUB_REPOSITORY
 common::check_env GITHUB_REF_NAME
 common::check_env NEW_TAG
 
-# Prepare --field flags for each changed file
 files=()
 while IFS= read -r f; do
   files+=(--field "files[][path]=$f")
   files+=(--field "files[][contents]=$(base64 -w0 "$f")")
-done < <(git status --porcelain | awk '{print $2}')
+done < <(git status --porcelain | awk '{print $2}' | xargs --no-run-if-empty -I{} find {} -type f 2>/dev/null)
 
 # Commit changes
 new_sha=$(

--- a/.github/workflows/__bump-and-build.yaml
+++ b/.github/workflows/__bump-and-build.yaml
@@ -28,6 +28,9 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
+    - name: "Setup Cache"
+      uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+
     - name: "Mise Install"
       uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
 

--- a/mise.toml
+++ b/mise.toml
@@ -35,7 +35,7 @@ run = "rm -rf docs/man"
 [tasks."clean::gen::docs"]
 description = "Clean generated documentation"
 depends = ["clean::gen::docs::**"]
-run = "rm -f docs"
+run = "rm -rf docs"
 
 [tasks."clean::gen"]
 description = "Clean everything generated"


### PR DESCRIPTION
- ensures all files (even nested in directories) are included in commit by using `find ... -type f`
- updates `clean::gen::docs` task to `rm -rf docs` to properly clean generated files
- add Rust cache setup to bump-and-build workflow