### PR TITLE
chore(man): fix subcommand prefix rendering and enable clap string support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [workspace.dependencies]
 af = { path = ""}
 anyhow = "1.0.97"
-clap = { version = "4.5.31", features = ["derive", "env"] }
+clap = { version = "4.5.31", features = ["derive", "env", "string"] }
 clap-verbosity-flag = "3.0.2"
 clap_complete_command = "0.6.1"
 cli-clipboard = "0.4.0"

--- a/xtasks/genman/src/main.rs
+++ b/xtasks/genman/src/main.rs
@@ -1,35 +1,35 @@
 use af::Cli;
 use clap::{Command, CommandFactory};
 use clap_mangen::Man;
-use std::{env, ffi::OsString, fs, path::PathBuf};
+use std::{env, fs, path::{Path, PathBuf}};
 
 const PATH_MAN_DEFAULT: &str = "docs/man/man1";
 const PATH_MAN_ENV_VAR: &str = "OUT_PATH_MAN";
 
 fn main() -> anyhow::Result<()> {
     let root_cmd = Cli::command();
+    let out_path = env::var_os(PATH_MAN_ENV_VAR)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PATH_MAN_DEFAULT.into());
 
-    let out_path_man: PathBuf = env::var_os(PATH_MAN_ENV_VAR)
-        .unwrap_or_else(|| OsString::from(PATH_MAN_DEFAULT))
-        .into();
+    fs::create_dir_all(&out_path)?;
 
-    fs::create_dir_all(&out_path_man)?;
-
-    generate_man_pages(&root_cmd, &out_path_man, root_cmd.get_name())?;
-
+    generate_man_pages(&root_cmd, &out_path, vec![root_cmd.get_name()])?;
+    
     Ok(())
 }
 
-fn generate_man_pages(cmd: &Command, out_dir: &PathBuf, prefix: &str) -> anyhow::Result<()> {
-    let man = Man::new(cmd.clone());
-    let mut buffer: Vec<u8> = Vec::new();
-    man.render(&mut buffer)?;
+fn generate_man_pages(cmd: &Command, out_dir: &Path, prefixes: Vec<&str>) -> anyhow::Result<()> {
+    let man_cmd = cmd.clone().name(prefixes.join(" "));
+    let mut buffer = Vec::new();
+    Man::new(man_cmd.clone()).render(&mut buffer)?;
+    
+    fs::write(out_dir.join(format!("{}.1", prefixes.join("-"))), buffer)?;
 
-    fs::write(out_dir.join(format!("{}.1", prefix)), buffer)?;
-
-    for sub in cmd.get_subcommands() {
-        let sub_prefix = format!("{}-{}", prefix, sub.get_name());
-        generate_man_pages(sub, out_dir, &sub_prefix)?;
+    for sub in man_cmd.get_subcommands() {
+        let mut new_prefixes = prefixes.clone();
+        new_prefixes.push(sub.get_name());
+        generate_man_pages(sub, out_dir, new_prefixes)?;
     }
 
     Ok(())


### PR DESCRIPTION
- adds `string` feature to clap to allow custom `.name()` usage for manpages
- updates manpage generator to properly format subcommand names with hyphens
- simplifies path handling logic in `genman`