### PR TITLE
chore(renovate): tweak rules to customize PR body and improve automerge config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,13 +4,13 @@
   "extends": [
     "config:best-practices",
     ":gitSignOff",
-    ":label(dependencies)",
-    ":semanticCommitTypeAll(chore)"
+    ":label(dependencies)"
   ],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true
   },
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "packageRules": [
     {
       "description": "Automerge non-major updates",
@@ -18,7 +18,8 @@
         "minor",
         "patch"
       ],
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false
     }
   ]
 }


### PR DESCRIPTION
- removes forced chore commit type to allow custom titles
- disables dependency dashboard approval for non-major updates
- sets PR body template for consistent structure