### PR TITLE
feat(cli): add `dot` subcommand and improve CLI help messages

### DIFF
--- a/src/af/cmd/git/mod.rs
+++ b/src/af/cmd/git/mod.rs
@@ -1,1 +1,9 @@
+use clap::Subcommand;
+
 pub mod clone_project;
+
+#[derive(Debug, Subcommand)]
+pub enum GitCommands {
+    #[command(visible_alias = "cp")]
+    CloneProject(clone_project::GitCloneProjectArgs),
+}

--- a/src/af/consts.rs
+++ b/src/af/consts.rs
@@ -1,0 +1,29 @@
+// Common
+pub const AF: &str = "af";
+
+// Env vars
+pub const XPC_SERVICE_NAME: &str = "XPC_SERVICE_NAME";
+pub const HOME: &str = "HOME";
+
+// Languages
+pub const C: &str = "c";
+pub const CPP: &str = "c++";
+pub const GO: &str = "go";
+pub const JS: &str = "javascript";
+pub const RUBY: &str = "ruby";
+pub const RUST: &str = "rust";
+
+// IDEs
+pub const CLION: &str = "clion";
+pub const GOLAND: &str = "goland";
+pub const RUBYMINE: &str = "rubymine";
+pub const RUSTROVER: &str = "rustrover";
+pub const WEBSTORM: &str = "webstorm";
+
+// Commands
+pub const WHICH: &str = "which";
+pub const GIT: &str = "git";
+
+// Git specific
+pub const ORIGIN: &str = "origin";
+pub const UPSTREAM: &str = "upstream";

--- a/src/af/ides.rs
+++ b/src/af/ides.rs
@@ -1,13 +1,15 @@
+use crate::consts::*;
+use phf::ordered_map::OrderedMap;
 use phf::phf_ordered_map;
 use std::collections::BTreeSet;
 
-static LANGS_IDES_MAP: phf::ordered_map::OrderedMap<&str, &str> = phf_ordered_map! {
-    "c" => "clion",
-    "c++" => "clion",
-    "go" => "goland",
-    "javascript" => "webstorm",
-    "ruby" => "rubymine",
-    "rust" => "rustrover",
+static LANGS_IDES_MAP: OrderedMap<&str, &str> = phf_ordered_map! {
+    "c" => CLION,
+    "c++" => CLION,
+    "go" => GOLAND,
+    "javascript" => WEBSTORM,
+    "ruby" => RUBYMINE,
+    "rust" => RUSTROVER,
 };
 
 pub fn get(language: &str) -> Option<&'static str> {
@@ -22,5 +24,5 @@ pub fn list() -> Vec<&'static str> {
 
 #[test]
 fn test_values() {
-    assert_eq!(list(), vec!["clion", "goland", "rubymine", "rustrover", "webstorm"]);
+    assert_eq!(list(), vec![CLION, GOLAND, RUBYMINE, RUSTROVER, WEBSTORM]);
 }

--- a/src/af/repo.rs
+++ b/src/af/repo.rs
@@ -1,9 +1,10 @@
-use regex::Regex;
-use anyhow::anyhow;
-use std::collections::BTreeMap;
-use log::debug;
+use crate::consts::*;
 use crate::ides;
 use crate::utils;
+use anyhow::anyhow;
+use log::debug;
+use regex::Regex;
+use std::collections::BTreeMap;
 
 #[derive(Debug)]
 pub struct Repo<'a> {
@@ -22,7 +23,7 @@ impl<'a> Repo<'a> {
             .ok_or_else(|| anyhow!("Invalid repository URL: {}", url))?;
 
         Ok(Self {
-            username: "git", // Hardcoded since it's always 'git'
+            username: GIT, // Hardcoded since it's always 'git'
             host: captures.get(1).unwrap().as_str(),
             org: captures.get(2).unwrap().as_str(),
             name: captures.get(3).unwrap().as_str(),
@@ -56,7 +57,7 @@ impl<'a> Repo<'a> {
             if let Some(ide) = ides::get(language) {
                 debug!("found IDE for language {ide}");
 
-                if utils::run_command("which", &[ide])?.status.success() {
+                if utils::run_command(WHICH, &[ide])?.status.success() {
                     return Ok(Some(ide));
                 }
 

--- a/src/af/utils.rs
+++ b/src/af/utils.rs
@@ -1,11 +1,10 @@
-use std::{
-    env,
-    process::{Command, Output}
-};
+use crate::consts::*;
 use anyhow::Context;
 use clio::ClioPath;
 use console::style;
 use log::trace;
+use std::env;
+use std::process::{Command, Output};
 
 pub fn run_command(command: &str, args: &[&str]) -> anyhow::Result<Output> {
     let output = Command::new(command)
@@ -29,5 +28,5 @@ pub fn format_directory(directory: &ClioPath) -> String {
     directory
         .display()
         .to_string()
-        .replace(env::var("HOME").unwrap_or_default().as_str(), "~")
+        .replace(env::var(HOME).unwrap_or_default().as_str(), "~")
 }


### PR DESCRIPTION
- adds new `dot` subcommand (alias: `.`) to open dotfiles in current/matching IDE
- adds `dot ide` subcommand with support for $DOTFILES_PATH override
- introduces centralized `consts.rs` for common strings and env vars
- improves help/usage messages for all subcommands, arguments, and flags
- rewrites CLI declarations to include missing descriptions and usage details
- restructures git helpers into `GitCommands` enum
- updates main logic to match subcommands and run helpers accordingly