### PR TITLE
chore(cli): enable help text wrapping and improve manpage generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1938,6 +1939,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [workspace.dependencies]
 af = { path = ""}
 anyhow = "1.0.97"
-clap = { version = "4.5.31", features = ["derive", "env", "string"] }
+clap = { version = "4.5.31", features = ["derive", "env", "string", "wrap_help"] }
 clap-verbosity-flag = "3.0.2"
 clap_complete_command = "0.6.1"
 cli-clipboard = "0.4.0"

--- a/src/af/lib.rs
+++ b/src/af/lib.rs
@@ -10,9 +10,10 @@ pub mod ides;
 pub mod repo;
 pub mod utils;
 
+/// The afrael CLI tool
 #[derive(Debug, Parser)] // requires `derive` feature
 #[command(name = AF)]
-#[command(version, about = "The afrael CLI tool", long_about = None)]
+#[command(version)]
 pub struct Cli {
     /// Top-level command to run
     #[command(subcommand)]


### PR DESCRIPTION
- enables `wrap_help` feature for `clap` to wrap long help messages in CLI
- improves manpage generation logic in `xtasks/genman` to support nested subcommands
- simplifies `Cli` definition to avoid duplicate `about` and allow full doc comment usage