### PR TITLE
feat(git/pgc): add support for converting HTTP(S) repository URLs to SSH

### DIFF
--- a/src/af/utils.rs
+++ b/src/af/utils.rs
@@ -1,12 +1,13 @@
 use crate::consts::*;
-use anyhow::Context;
+use anyhow::{Context, Result};
 use clio::ClioPath;
 use console::style;
 use log::trace;
+use regex::Regex;
 use std::env;
 use std::process::{Command, Output};
 
-pub fn run_command(command: &str, args: &[&str]) -> anyhow::Result<Output> {
+pub fn run_command(command: &str, args: &[&str]) -> Result<Output> {
     let output = Command::new(command)
         .args(args)
         .output()
@@ -29,4 +30,146 @@ pub fn format_directory(directory: &ClioPath) -> String {
         .display()
         .to_string()
         .replace(env::var(HOME).unwrap_or_default().as_str(), "~")
+}
+
+pub fn parse_repository(repository: &str) -> Result<String> {
+    let repo = repository.trim();
+
+    // check if in ssh format
+    if Regex::new(r"^git@([^/]+):([^/]+)/([^/]+)\.git$")?.is_match(repo) {
+        return Ok(repo.to_string());
+    }
+
+    // check if in http(s) format
+    if Regex::new(r"^https?://([^/]+)/([^/]+)/([^/]+)(?:/.*?)?$")?.is_match(repo) {
+        return Ok(repo.to_string());
+    }
+
+    anyhow::bail!(
+        "Unsupported repository URL. Supported formats: [{}, {}]",
+        style("git@<host>:<org>/<repo>.git").bold(),
+        style("http[s]://<host>/<org>/<repo>[/...]").bold(),
+    );
+}
+
+pub fn validate_repository(repository: &str) -> Result<()> {
+    parse_repository(repository).map(|_| ())
+}
+
+pub fn convert_to_ssh<S: AsRef<str>>(repository: S) -> Result<String> {
+    let repo = repository.as_ref().trim();
+
+    let re_ssh = Regex::new(r"^git@([^/]+):([^/]+)/([^/]+)\.git$")?;
+    if re_ssh.is_match(repo) {
+        return Ok(repo.to_string());
+    }
+
+    let re_https = Regex::new(r"^https?://([^/]+)/([^/]+)/([^/]+)(?:/.*)?$")?;
+    if let Some(caps) = re_https.captures(repo) {
+        return Ok(format!("git@{}:{}/{}.git", &caps[1], &caps[2], &caps[3]));
+    }
+
+    anyhow::bail!("Only http(s) repository URLs are supported for conversion");
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_ssh_url() {
+        let url = "git@github.com:org/repo.git";
+        let parsed = parse_repository(url).unwrap();
+        assert_eq!(parsed, url.trim());
+    }
+
+    #[test]
+    fn parses_valid_https_url() {
+        let url = "https://github.com/org/repo";
+        let parsed = parse_repository(url).unwrap();
+        assert_eq!(parsed, url.trim());
+    }
+
+    #[test]
+    fn parses_valid_https_url_with_trailing_path() {
+        let url = "https://github.com/org/repo/tree/main";
+        let parsed = parse_repository(url).unwrap();
+        assert_eq!(parsed, url.trim());
+    }
+
+    #[test]
+    fn trims_whitespace_before_parsing() {
+        let url = "  git@github.com:org/repo.git  ";
+        let parsed = parse_repository(url).unwrap();
+        assert_eq!(parsed, "git@github.com:org/repo.git");
+    }
+
+    #[test]
+    fn fails_on_invalid_url() {
+        let url = "ftp://github.com/org/repo";
+        let err = parse_repository(url).unwrap_err().to_string();
+        assert!(
+            err.contains("Unsupported repository URL"),
+            "unexpected error message: {}",
+            err
+        );
+    }
+
+    // convert_to_ssh
+
+    #[test]
+    fn return_ssh() {
+        let url = "git@github.com:org/repo.git";
+        let ssh = convert_to_ssh(url).unwrap();
+        assert_eq!(ssh, "git@github.com:org/repo.git");
+    }
+
+    #[test]
+    fn converts_https_to_ssh() {
+        let url = "https://github.com/org/repo";
+        let ssh = convert_to_ssh(url).unwrap();
+        assert_eq!(ssh, "git@github.com:org/repo.git");
+    }
+
+    #[test]
+    fn converts_http_to_ssh() {
+        let url = "http://gitlab.com/group/project";
+        let ssh = convert_to_ssh(url).unwrap();
+        assert_eq!(ssh, "git@gitlab.com:group/project.git");
+    }
+
+    #[test]
+    fn strips_trailing_git_suffix() {
+        let url = "https://bitbucket.org/team/repo.git";
+        let ssh = convert_to_ssh(url).unwrap();
+        assert_eq!(ssh, "git@bitbucket.org:team/repo.git");
+    }
+
+    #[test]
+    fn ignores_extra_path_parts() {
+        let url = "https://github.com/org/repo/tree/main";
+        let ssh = convert_to_ssh(url).unwrap();
+        assert_eq!(ssh, "git@github.com:org/repo.git");
+    }
+
+    #[test]
+    fn trims_input() {
+        let url = "  https://github.com/org/repo  ";
+        let ssh = convert_to_ssh(url).unwrap();
+        assert_eq!(ssh, "git@github.com:org/repo.git");
+    }
+
+    #[test]
+    fn returns_error_on_non_http_url() {
+        let url = "git@github.com:org/repo.git";
+        let result = convert_to_ssh(url);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Only http(s) repository URLs are supported")
+        );
+    }
 }


### PR DESCRIPTION
This adds a new `--convert-to-ssh` flag (enabled by default) to the `git clone-project` subcommand, allowing automatic conversion of HTTP(S) repository URLs (e.g., copied from a browser) into SSH format before cloning.

The repository parsing logic has been moved into `utils.rs` and now supports both SSH and HTTPS-style URLs. When the `--convert-to-ssh` flag is set, HTTPS URLs are normalized to `git@host:org/repo.git`.

Also, updated clipboard handling to show more context and confirmation prompt formatting to improve clarity. Includes unit tests for all supported formats and edge cases.