### PR TITLE
refactor(cli): restructure command layout and improve help content

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,9 @@ pandoc = "3.6.4"
 description = "Generate markdown documentation"
 run = """
 cargo genmd
-pandoc --from markdown --to gfm --wrap none --output docs/af.md docs/af.md
+for f in docs/*.md; do
+    pandoc --from markdown --to gfm --wrap none --output "$f" "$f"
+done
 """
 
 [tasks."gen::docs::man"]

--- a/src/af/cmd/dot.rs
+++ b/src/af/cmd/dot.rs
@@ -1,0 +1,74 @@
+use crate::consts::{GO, XPC_SERVICE_NAME};
+use crate::{ides, utils};
+use anyhow::{anyhow, Result};
+use clap::{ValueHint, value_parser, Args, Subcommand};
+use clio::ClioPath;
+use regex::Regex;
+use std::env;
+
+#[derive(Debug, Args)]
+#[command(visible_alias = ".")]
+#[command(args_conflicts_with_subcommands = true)]
+#[command(flatten_help = true)]
+#[command(disable_help_subcommand = true)]
+pub struct Dot {
+    /// Optional dotfiles subcommand
+    #[command(subcommand)]
+    pub command: Option<DotCommands>,
+
+    /// IDE-related options (used when no subcommand is given)
+    #[command(flatten)]
+    pub ide: Ide,
+}
+
+impl Dot {
+    pub fn run(&self) -> Result<()> {
+        match &self.command {
+            Some(DotCommands::Ide(args)) => args.run(),
+            None => self.ide.run(),
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum DotCommands {
+    /// Open the dotfiles directory in an IDE
+    ///
+    /// If inside a JetBrains IDE, it will use that IDE to open the path.
+    /// Otherwise, it tries to open in GoLand.
+    Ide(Ide),
+}
+
+#[derive(Debug, Args)]
+pub struct Ide {
+    /// Path to the dotfiles directory (overrides $DOTFILES_PATH)
+    #[arg(
+        long,
+        env = "DOTFILES_PATH",
+        value_hint = ValueHint::DirPath,
+        value_parser = value_parser!(ClioPath).exists().is_dir(),
+    )]
+    pub path: Option<ClioPath>,
+}
+
+impl Ide {
+    pub fn run(&self) -> Result<()> {
+        let re = Regex::new(r"application\.com\.jetbrains\.(\w+)(?:-.+)?(?:\.\d+)*")?;
+        let xpc_service_name = env::var(XPC_SERVICE_NAME).unwrap_or_default();
+        let ide = re
+            .captures(&xpc_service_name)
+            .map(|c| c.get(1).map_or("", |m| m.as_str()));
+
+        let ides = ides::list();
+
+        let index = ides
+            .binary_search(&ide.unwrap_or(ides::get(GO).unwrap()))
+            .map_err(|e| anyhow!("{:?}", e))?;
+
+        if let Some(p) = &self.path {
+            utils::run_command(ides[index], &[p.to_str().unwrap()])?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/af/cmd/git/clone_project/mod.rs
+++ b/src/af/cmd/git/clone_project/mod.rs
@@ -17,8 +17,7 @@ use thiserror::Error;
 
 /// Clone a project repository and optionally open it in an IDE
 #[derive(Debug, Args)]
-#[command()]
-pub struct GitCloneProjectArgs {
+pub struct CloneProject {
     /// The repository URL to clone (e.g. git@github.com:org/project.git)
     #[arg(value_parser = utils::parse_repository)]
     repository_url: Option<String>,
@@ -54,7 +53,7 @@ pub struct GitCloneProjectArgs {
     convert_to_ssh: std::primitive::bool,
 }
 
-impl GitCloneProjectArgs {
+impl CloneProject {
     pub async fn run(&self, multi_progress: &MultiProgress) -> Result<()> {
         trace!("Arguments: {:?}", self);
 

--- a/src/af/cmd/git/mod.rs
+++ b/src/af/cmd/git/mod.rs
@@ -1,9 +1,19 @@
+use anyhow::Result;
 use clap::Subcommand;
+use indicatif::MultiProgress;
 
 pub mod clone_project;
 
 #[derive(Debug, Subcommand)]
-pub enum GitCommands {
+pub enum Git {
     #[command(visible_alias = "cp")]
-    CloneProject(clone_project::GitCloneProjectArgs),
+    CloneProject(clone_project::CloneProject),
+}
+
+impl Git {
+    pub async fn run(&self, multi: &MultiProgress) -> Result<()> {
+        match self {
+            Git::CloneProject(args) => args.run(multi).await,
+        }
+    }
 }

--- a/src/af/cmd/mod.rs
+++ b/src/af/cmd/mod.rs
@@ -1,1 +1,2 @@
 pub mod git;
+pub mod dot;

--- a/src/af/consts.rs
+++ b/src/af/consts.rs
@@ -1,3 +1,5 @@
+use fern::colors::Color;
+
 // Common
 pub const AF: &str = "af";
 
@@ -27,3 +29,15 @@ pub const GIT: &str = "git";
 // Git specific
 pub const ORIGIN: &str = "origin";
 pub const UPSTREAM: &str = "upstream";
+
+// Colors
+pub const GREY: Color = Color::TrueColor {
+    r: 107,
+    g: 107,
+    b: 107,
+};
+pub const MUTED_TEAL: Color = Color::TrueColor {
+    r: 117,
+    g: 195,
+    b: 170,
+};

--- a/src/af/lib.rs
+++ b/src/af/lib.rs
@@ -1,8 +1,9 @@
-use clap::value_parser;
-use clap::{Args, ValueHint};
-use clap::{Parser, Subcommand};
-use clio::ClioPath;
-use consts::*;
+use crate::consts::AF;
+use anyhow::Result;
+use clap::{CommandFactory, Parser, Subcommand, command};
+use cmd::{dot::Dot, git::Git, git::clone_project::CloneProject};
+use indicatif::MultiProgress;
+use log::LevelFilter;
 
 pub mod cmd;
 pub mod consts;
@@ -10,26 +11,39 @@ pub mod ides;
 pub mod repo;
 pub mod utils;
 
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
+
 /// The afrael CLI tool
 #[derive(Debug, Parser)] // requires `derive` feature
 #[command(name = AF)]
 #[command(version)]
-pub struct Cli {
-    /// Top-level command to run
-    #[command(subcommand)]
-    pub command: Commands,
-
-    /// Increase output verbosity (-v, -vv, -vvv, etc.)
+#[command(multicall = true)]
+pub enum Cli {
     #[command(flatten)]
-    pub verbose: clap_verbosity_flag::Verbosity,
+    Applet(Applet),
 
-    /// Enable debug output
-    #[arg(long, global = true)]
-    pub debug: bool,
+    #[command(subcommand)]
+    Af(Applet),
+}
+
+impl Cli {
+    pub fn log_level_filter(&self) -> LevelFilter {
+        match self {
+            Cli::Applet(cmd) => cmd.log_level_filter(),
+            Cli::Af(cmd) => cmd.log_level_filter(),
+        }
+    }
+
+    pub async fn run(&self, multi: MultiProgress) -> Result<()> {
+        match self {
+            Cli::Applet(cmd) => cmd.run(multi).await,
+            Cli::Af(cmd) => cmd.run(multi).await,
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
-pub enum Commands {
+pub enum Applet {
     /// Generate shell completion scripts
     Completions {
         /// Target shell to generate completions for
@@ -38,52 +52,60 @@ pub enum Commands {
     },
 
     /// Helper commands related to dotfiles (defaults to `dot ide` if no subcommand is used)
-    Dot(DotArgs),
+    Dot {
+        #[command(flatten)]
+        dot: Dot,
+
+        /// Increase output verbosity (-v, -vv, -vvv, etc.)
+        #[command(flatten)]
+        verbose: clap_verbosity_flag::Verbosity,
+    },
 
     /// Git-related helper commands
     #[command(visible_alias = "g")]
     Git {
         #[command(subcommand)]
-        command: cmd::git::GitCommands,
+        git: Git,
+
+        /// Increase output verbosity (-v, -vv, -vvv, etc.)
+        #[command(flatten)]
+        verbose: clap_verbosity_flag::Verbosity,
     },
 
     /// Shortcut for `af git clone-project`
     #[command(name = "pgc")]
-    ProjectGitClone(cmd::git::clone_project::GitCloneProjectArgs),
+    ProjectGitClone {
+        #[command(flatten)]
+        clone_project: CloneProject,
+
+        /// Increase output verbosity (-v, -vv, -vvv, etc.)
+        #[command(flatten)]
+        verbose: clap_verbosity_flag::Verbosity,
+    },
 }
 
-#[derive(Debug, Args)]
-#[command(visible_alias = ".")]
-#[command(args_conflicts_with_subcommands = true)]
-#[command(flatten_help = true)]
-#[command(disable_help_subcommand = true)]
-pub struct DotArgs {
-    /// Optional dotfiles subcommand
-    #[command(subcommand)]
-    pub command: Option<DotCommands>,
+impl Applet {
+    fn log_level_filter(&self) -> LevelFilter {
+        match self {
+            Applet::Dot { verbose, .. } => verbose.log_level_filter(),
+            Applet::Git { verbose, .. } => verbose.log_level_filter(),
+            Applet::ProjectGitClone { verbose, .. } => verbose.log_level_filter(),
+            _ => DEFAULT_LOG_LEVEL,
+        }
+    }
 
-    /// IDE-related options (used when no subcommand is given)
-    #[command(flatten)]
-    pub ide: DotCommandsIdeArgs,
-}
+    pub async fn run(&self, multi: MultiProgress) -> Result<()> {
+        match self {
+            Applet::Completions { shell, .. } => {
+                shell.generate(&mut Cli::command(), &mut std::io::stdout());
+                Ok(())
+            }
 
-#[derive(Debug, Subcommand)]
-pub enum DotCommands {
-    /// Open the dotfiles directory in an IDE
-    ///
-    /// If inside a JetBrains IDE, it will use that IDE to open the path.
-    /// Otherwise, it tries to open in GoLand.
-    Ide(DotCommandsIdeArgs),
-}
+            Applet::Dot { dot, .. } => dot.run(),
 
-#[derive(Debug, Args)]
-pub struct DotCommandsIdeArgs {
-    /// Path to the dotfiles directory (overrides $DOTFILES_PATH)
-    #[arg(
-        long,
-        env = "DOTFILES_PATH",
-        value_hint = ValueHint::DirPath,
-        value_parser = value_parser!(ClioPath).exists().is_dir(),
-    )]
-    pub path: Option<ClioPath>,
+            Applet::Git { git, .. } => git.run(&multi).await,
+
+            Applet::ProjectGitClone { clone_project, .. } => clone_project.run(&multi).await,
+        }
+    }
 }

--- a/src/bin/af.rs
+++ b/src/bin/af.rs
@@ -1,103 +1,16 @@
-use af::{Cli, Commands, DotCommands, cmd, consts::*, ides, utils};
-use anyhow::anyhow;
-use clap::{CommandFactory, Parser};
-use fern::colors::{Color, ColoredLevelConfig};
+use af::{utils, Cli};
+use clap::Parser;
 use indicatif::MultiProgress;
 use indicatif_log_bridge::LogWrapper;
-use regex::Regex;
-use std::env;
-use std::time::SystemTime;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-
+    let (level, logger) = utils::setup_logger(cli.log_level_filter());
     let multi = MultiProgress::new();
-
-    let colors = ColoredLevelConfig::new()
-        // use builder methods
-        .error(Color::Red)
-        .warn(Color::Yellow)
-        .info(Color::Green)
-        .debug(Color::Blue)
-        .trace(Color::TrueColor {
-            r: 117,
-            g: 195,
-            b: 170,
-        });
-
-    let (level, logger) = fern::Dispatch::new()
-        .format(move |out, message, record| {
-            out.finish(format_args!(
-                "{left_bracket}{timestamp} {level} {target}{right_bracket} {message}",
-                left_bracket = format_args!(
-                    "\x1B[{}m[\x1B[0m",
-                    Color::TrueColor {
-                        r: 107,
-                        g: 107,
-                        b: 107
-                    }
-                    .to_fg_str(),
-                ),
-                timestamp = humantime::format_rfc3339_seconds(SystemTime::now()),
-                level = colors.color(record.level()),
-                target = record.target(),
-                right_bracket = format_args!(
-                    "\x1B[{}m]\x1B[0m",
-                    Color::TrueColor {
-                        r: 107,
-                        g: 107,
-                        b: 107
-                    }
-                    .to_fg_str(),
-                ),
-                message = message
-            ))
-        })
-        .level(if cli.debug {
-            log::LevelFilter::Trace
-        } else {
-            log::LevelFilter::Error
-        })
-        .level_for("af", cli.verbose.log_level_filter())
-        .chain(std::io::stdout())
-        .into_log();
-
+    
     LogWrapper::new(multi.clone(), logger).try_init()?;
     log::set_max_level(level);
 
-    match cli.command {
-        Commands::Completions { shell } => {
-            shell.generate(&mut Cli::command(), &mut std::io::stdout())
-        }
-
-        Commands::Dot(dot) => match dot.command.unwrap_or(DotCommands::Ide(dot.ide)) {
-            DotCommands::Ide(args) => {
-                let re = Regex::new(r"application\.com\.jetbrains\.(\w+)(?:-.+)?(?:\.\d+)*")?;
-                let xpc_service_name = env::var(XPC_SERVICE_NAME).unwrap_or_default();
-                let ide = re
-                    .captures(&xpc_service_name)
-                    .map(|c| c.get(1).map_or("", |m| m.as_str()));
-
-                let ides = ides::list();
-
-                let index = ides
-                    .binary_search(&ide.unwrap_or(ides::get(GO).unwrap()))
-                    .map_err(|e| anyhow!("{:?}", e))?;
-
-                if let Some(p) = args.path {
-                    utils::run_command(ides[index], &[p.to_str().unwrap()])?;
-                }
-            }
-        },
-
-        Commands::Git { command } => match command {
-            cmd::git::GitCommands::CloneProject(args) => args.run(&multi).await?,
-        },
-
-        // Aliases
-        Commands::ProjectGitClone(args) => args.run(&multi).await?,
-    }
-
-    Ok(())
+    cli.run(multi).await
 }

--- a/xtasks/genman/src/main.rs
+++ b/xtasks/genman/src/main.rs
@@ -1,4 +1,4 @@
-use af::Cli;
+use af::{Cli, consts::AF};
 use clap::{Command, CommandFactory};
 use clap_mangen::Man;
 use std::{env, fs, io, path::{Path, PathBuf}};
@@ -7,25 +7,39 @@ const PATH_MAN_DEFAULT: &str = "docs/man/man1";
 const PATH_MAN_ENV_VAR: &str = "OUT_PATH_MAN";
 
 fn main() -> anyhow::Result<()> {
-    let root_cmd = Cli::command();
     let out_path = env::var_os(PATH_MAN_ENV_VAR)
         .map(PathBuf::from)
         .unwrap_or_else(|| PATH_MAN_DEFAULT.into());
 
     fs::create_dir_all(&out_path)?;
 
-    generate_man_pages(&root_cmd, &out_path, vec![root_cmd.get_name()])?;
-    
+    let cmd = Cli::command()
+        .find_subcommand(AF)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(Cli::command);
+
+    generate_man_pages(&cmd, &out_path, vec![cmd.get_name()])?;
+
     Ok(())
 }
 
-fn generate_man_pages(root_cmd: &Command, out_dir: &Path, prefixes: Vec<&str>) -> Result<PathBuf, io::Error> {
+fn generate_man_pages(
+    root_cmd: &Command,
+    out_dir: &Path,
+    prefixes: Vec<&str>,
+) -> Result<PathBuf, io::Error> {
     let name = prefixes.join("-");
     let cmd = root_cmd.clone().name(&name).bin_name(prefixes.join(" "));
-    
+
     for subcmd in cmd.get_subcommands() {
-        generate_man_pages(subcmd, out_dir, [prefixes.as_slice(), &[subcmd.get_name()]].concat())?;
+        generate_man_pages(
+            subcmd,
+            out_dir,
+            [prefixes.as_slice(), &[subcmd.get_name()]].concat(),
+        )?;
     }
 
-    Man::new(cmd).title(name.to_uppercase()).generate_to(out_dir)
+    Man::new(cmd)
+        .title(name.to_uppercase())
+        .generate_to(out_dir)
 }

--- a/xtasks/genmd/src/main.rs
+++ b/xtasks/genmd/src/main.rs
@@ -1,29 +1,28 @@
-use af::Cli;
+use af::{Cli, consts::AF};
 use clap::CommandFactory;
-use clap_markdown::{help_markdown_command_custom, MarkdownOptions};
-use std::ffi::OsString;
-use std::path::PathBuf;
-use std::{env, fs};
+use clap_markdown::{MarkdownOptions, help_markdown_command_custom};
+use std::{env, ffi::OsString, fs, path::PathBuf};
 
 const PATH_DOCS_DEFAULT: &str = "docs";
 const PATH_MD_ENV_VAR: &str = "OUT_PATH_MD";
 
 fn main() -> anyhow::Result<()> {
-    let cmd = Cli::command();
-
-    // Prepare paths
     let out_path_md: PathBuf = env::var_os(PATH_MD_ENV_VAR)
         .unwrap_or(OsString::from(PATH_DOCS_DEFAULT))
         .into();
 
     fs::create_dir_all(&out_path_md)?;
 
-    // Prepare Markdown
+    let cmd = Cli::command()
+        .find_subcommand(AF)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(Cli::command);
+
+    let path = out_path_md.join(format!("{}.md", cmd.get_name()));
     let options = MarkdownOptions::new().show_footer(false);
     let markdown = help_markdown_command_custom(&cmd, &options);
 
-    // Write results to files
-    fs::write(out_path_md.join(format!("{}.md", cmd.get_name())), markdown)?;
+    fs::write(path, markdown)?;
 
     Ok(())
 }


### PR DESCRIPTION
Redesigned command structure to use multicall enum and applet separation, which simplifies argument parsing and runtime dispatch. Help messages were improved for clarity and consistency across subcommands. Logger setup was refactored for reuse and theme consistency. Generated Markdown and man pages now reflect these changes accurately.