### PR TITLE
feat(shortcuts): add support for Git command abbreviations

### DIFF
--- a/src/af/cmd/git/clone_project/mod.rs
+++ b/src/af/cmd/git/clone_project/mod.rs
@@ -6,13 +6,11 @@ use clap::{Args, ValueHint, value_parser};
 use clio::ClioPath;
 use console::style;
 use dialoguer::{Confirm, FuzzySelect, Input, theme::ColorfulTheme};
-use git2::build::RepoBuilder;
-use git2::{Cred, FetchOptions, RemoteCallbacks, Repository, StatusOptions};
+use git2::{build::RepoBuilder, Cred, FetchOptions, RemoteCallbacks, Repository, StatusOptions};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use log::{debug, info, trace};
 use regex::Regex;
-use std::time::Duration;
-use std::{env, fs};
+use std::{env, fs, time::Duration};
 use thiserror::Error;
 
 /// Clone a project repository and optionally open it in an IDE

--- a/src/af/cmd/mod.rs
+++ b/src/af/cmd/mod.rs
@@ -1,2 +1,3 @@
-pub mod git;
 pub mod dot;
+pub mod git;
+pub mod shortcuts;

--- a/src/af/cmd/shortcuts/abbreviations/mod.rs
+++ b/src/af/cmd/shortcuts/abbreviations/mod.rs
@@ -1,0 +1,77 @@
+use anyhow::bail;
+use clap::Subcommand;
+use git2::Repository;
+
+const REMOTE_NAMES: [&str; 2] = ["upstream", "origin"];
+
+#[derive(Debug, Subcommand)]
+pub enum Abbreviation {
+    /// Expands to: git checkout <default-branch> && git fetch <remote> && git merge --ff-only <remote>/<default-branch>
+    #[command(name = "gcmff")]
+    GitCheckoutMasterFetchFastForward,
+}
+
+impl Abbreviation {
+    pub fn run(&self) -> anyhow::Result<()> {
+        match self {
+            Abbreviation::GitCheckoutMasterFetchFastForward => {
+                let repo = Repository::open_from_env()?;
+
+                let (remote, default_branch) = get_remote_and_default_branch(&repo)?;
+
+                let head = repo
+                    .head()
+                    .ok()
+                    .and_then(|h| h.shorthand().map(str::to_string))
+                    .unwrap_or_default();
+
+                if head != default_branch {
+                    print!("git checkout {default_branch} && ");
+                }
+
+                print!("git fetch {remote} && git merge --ff-only {remote}/{default_branch}");
+
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Shortcut {
+    /// Group of abbreviation subcommands (alias: a, abbr, abbreviation)
+    #[command(visible_aliases = ["a", "abbr", "abbreviation"])]
+    #[command(subcommand)]
+    Abbreviations(Abbreviation),
+}
+
+impl Shortcut {
+    pub fn run(&self) -> anyhow::Result<()> {
+        match self {
+            // Delegates to the selected abbreviation command
+            Shortcut::Abbreviations(cmd) => cmd.run(),
+        }
+    }
+}
+
+/// Returns the first found remote (from REMOTE_NAMES) and its default branch name
+fn get_remote_and_default_branch(repo: &Repository) -> anyhow::Result<(String, String)> {
+    for remote_name in REMOTE_NAMES {
+        if repo.find_remote(remote_name).is_ok() {
+            let clean_pattern = format!("{remote_name}/");
+            let revparse_spec = format!("{clean_pattern}HEAD");
+
+            if let Ok((_, Some(reference))) = repo.revparse_ext(&revparse_spec) {
+                if let Some(ref_short) = reference.shorthand() {
+                    return Ok((
+                        remote_name.to_string(),
+                        ref_short.replace(&clean_pattern, ""),
+                    ));
+                }
+            }
+        }
+    }
+
+    // No matching remote and HEAD found
+    bail!("Could not find remote and default branch")
+}

--- a/src/af/cmd/shortcuts/mod.rs
+++ b/src/af/cmd/shortcuts/mod.rs
@@ -1,0 +1,1 @@
+pub mod abbreviations;

--- a/src/af/lib.rs
+++ b/src/af/lib.rs
@@ -1,7 +1,9 @@
 use crate::consts::AF;
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand, command};
-use cmd::{dot::DotCmd, git::Git, git::clone_project::CloneProject};
+use cmd::{
+    dot::DotCmd, git::Git, git::clone_project::CloneProject, shortcuts::abbreviations::Shortcut,
+};
 use indicatif::MultiProgress;
 use log::LevelFilter;
 
@@ -82,6 +84,10 @@ pub enum Applet {
         #[command(flatten)]
         verbose: clap_verbosity_flag::Verbosity,
     },
+
+    /// Short aliases for common command combinations (e.g. gcmff)
+    #[command(subcommand)]
+    Shortcuts(Shortcut),
 }
 
 impl Applet {
@@ -90,6 +96,7 @@ impl Applet {
             Applet::Dot { verbose, .. } => verbose.log_level_filter(),
             Applet::Git { verbose, .. } => verbose.log_level_filter(),
             Applet::ProjectGitClone { verbose, .. } => verbose.log_level_filter(),
+            Applet::Shortcuts(_) => LevelFilter::Off,
             _ => DEFAULT_LOG_LEVEL,
         }
     }
@@ -104,6 +111,8 @@ impl Applet {
             Applet::Dot { dot, .. } => dot.run(),
 
             Applet::Git { git, .. } => git.run(&multi).await,
+
+            Applet::Shortcuts(shortcut) => shortcut.run(),
 
             Applet::ProjectGitClone { clone_project, .. } => clone_project.run(&multi).await,
         }


### PR DESCRIPTION
Introduced `af shortcuts` subcommand group to define and run abbreviated Git workflows. Added the initial `gcmff` abbreviation to output: `git checkout <branch> && git fetch <remote> && git merge --ff-only <remote>/<branch>`.