### PR TITLE
fix(shortcuts): make abbreviations log errors instead of returning them

### DIFF
--- a/src/af/lib.rs
+++ b/src/af/lib.rs
@@ -115,7 +115,10 @@ impl Applet {
 
             Applet::Git { git, .. } => git.run(&multi).await,
 
-            Applet::Shortcuts(shortcut) => shortcut.run(),
+            Applet::Shortcuts(shortcut) => {
+                shortcut.run();
+                Ok(())
+            },
 
             Applet::ProjectGitClone { clone_project, .. } => clone_project.run(&multi).await,
         }


### PR DESCRIPTION
Changed abbreviation and shortcut handlers to always succeed. Failures are now logged with `debug!` instead of returning `Result`. Updated `Applet::Shortcuts` runner to return `Ok(())` after execution.