### PR TITLE
feat(shortcuts): add git push abbreviation with options

### DIFF
--- a/docs/af.md
+++ b/docs/af.md
@@ -14,6 +14,7 @@ This document contains the help content for the `af` command-line program.
 - [`af shortcuts`↴](#af-shortcuts)
 - [`af shortcuts abbreviations`↴](#af-shortcuts-abbreviations)
 - [`af shortcuts abbreviations gcmff`↴](#af-shortcuts-abbreviations-gcmff)
+- [`af shortcuts abbreviations gp`↴](#af-shortcuts-abbreviations-gp)
 
 ## `af`
 
@@ -162,11 +163,16 @@ Shortcut for `af git clone-project`
 
 Short aliases for common command combinations (e.g. gcmff)
 
-**Usage:** `af shortcuts <COMMAND>`
+**Usage:** `af shortcuts [OPTIONS] <COMMAND>`
 
 ###### **Subcommands:**
 
 - `abbreviations` — Group of abbreviation subcommands (alias: a, abbr, abbreviation)
+
+###### **Options:**
+
+- `-v`, `--verbose` — Increase logging verbosity
+- `-q`, `--quiet` — Decrease logging verbosity
 
 ## `af shortcuts abbreviations`
 
@@ -177,9 +183,30 @@ Group of abbreviation subcommands (alias: a, abbr, abbreviation)
 ###### **Subcommands:**
 
 - `gcmff` — Expands to: git checkout <default-branch> && git fetch <remote> && git merge –ff-only <remote>/<default-branch>
+- `gp` — Expands to: git push <remote> <branch> \[optional flags\]
 
 ## `af shortcuts abbreviations gcmff`
 
 Expands to: git checkout <default-branch> && git fetch <remote> && git merge –ff-only <remote>/<default-branch>
 
 **Usage:** `af shortcuts abbreviations gcmff`
+
+## `af shortcuts abbreviations gp`
+
+Expands to: git push <remote> <branch> \[optional flags\]
+
+**Usage:** `af shortcuts abbreviations gp [OPTIONS]`
+
+###### **Options:**
+
+- `-r`, `--remote <REMOTE_PRIORITY>` — Remote priority strategy when pushing (e.g., upstream first, origin first)
+
+  Default value: `origin-first`
+
+  Possible values: `origin-first`, `origin`, `upstream-first`, `upstream`
+
+- `-n`, `--no-verify` — Push with –no-verify flag (skip pre-push hooks)
+
+- `-f`, `--force-with-lease` — Push with –force-with-lease flag (safe force push)
+
+- `-F`, `--force` — Push with –force flag (unsafe force push, overrides remote)

--- a/src/af/cmd/shortcuts/abbreviations/mod.rs
+++ b/src/af/cmd/shortcuts/abbreviations/mod.rs
@@ -1,22 +1,70 @@
 use anyhow::bail;
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 use git2::Repository;
 use log::debug;
+use std::fmt::Debug;
+use std::{iter, slice, vec};
 
-const REMOTE_NAMES: [&str; 2] = ["upstream", "origin"];
+const ORIGIN: &[&str] = &["origin"];
+const UPSTREAM: &[&str] = &["upstream"];
+const UPSTREAM_ORIGIN: &[&str] = &["upstream", "origin"];
+const ORIGIN_UPSTREAM: &[&str] = &["origin", "upstream"];
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum GitPushRemote {
+    #[default]
+    OriginFirst,
+    Origin,
+    UpstreamFirst,
+    Upstream,
+}
+
+impl IntoIterator for GitPushRemote {
+    type Item = &'static str;
+    type IntoIter = iter::Copied<slice::Iter<'static, &'static str>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            GitPushRemote::Upstream => UPSTREAM.iter().copied(),
+            GitPushRemote::UpstreamFirst => UPSTREAM_ORIGIN.iter().copied(),
+            GitPushRemote::Origin => ORIGIN.iter().copied(),
+            GitPushRemote::OriginFirst => ORIGIN_UPSTREAM.iter().copied(),
+        }
+    }
+}
 
 #[derive(Debug, Subcommand)]
 pub enum Abbreviation {
     /// Expands to: git checkout <default-branch> && git fetch <remote> && git merge --ff-only <remote>/<default-branch>
     #[command(name = "gcmff")]
     GitCheckoutMasterFetchFastForward,
+
+    /// Expands to: git push <remote> <branch> [optional flags]
+    #[command(name = "gp")]
+    GitPush {
+        /// Remote priority strategy when pushing (e.g., upstream first, origin first)
+        #[arg(long = "remote", short, value_enum, default_value_t)]
+        remote_priority: GitPushRemote,
+
+        /// Push with --no-verify flag (skip pre-push hooks)
+        #[arg(long, short)]
+        no_verify: bool,
+
+        /// Push with --force-with-lease flag (safe force push)
+        #[arg(long, short)]
+        force_with_lease: bool,
+
+        /// Push with --force flag (unsafe force push, overrides remote)
+        #[arg(long, short = 'F', conflicts_with = "force_with_lease")]
+        force: bool,
+    },
 }
 
 impl Abbreviation {
     pub fn run(&self) {
         match self {
             Abbreviation::GitCheckoutMasterFetchFastForward => match Repository::open_from_env() {
-                Ok(repo) => match get_remote_and_default_branch(&repo) {
+                Ok(repo) => match get_remote_and_default_branch(&repo, UPSTREAM_ORIGIN) {
                     Ok((remote, default_branch)) => {
                         let head = repo
                             .head()
@@ -32,6 +80,40 @@ impl Abbreviation {
                             "git fetch {remote} && git merge --ff-only {remote}/{default_branch}"
                         );
                     }
+                    Err(err) => debug!("Failed to get remote and default branch: {err:#}"),
+                },
+                Err(err) => debug!("Failed to open repository from environment: {err:#}"),
+            },
+            Abbreviation::GitPush {
+                remote_priority,
+                no_verify,
+                force_with_lease,
+                force,
+            } => match Repository::open_from_env() {
+                Ok(repo) => match get_remote_and_default_branch(&repo, *remote_priority) {
+                    Ok((remote, _)) => match repo.head() {
+                        Ok(head) if head.is_branch() => {
+                            if let Some(branch) = head.shorthand() {
+                                let mut cmd = vec!["git", "push", &remote, branch];
+
+                                if *no_verify {
+                                    cmd.push("--no-verify");
+                                }
+
+                                if *force_with_lease {
+                                    cmd.push("--force-with-lease");
+                                } else if *force {
+                                    cmd.push("--force");
+                                }
+
+                                return print!("{}", cmd.join(" "));
+                            }
+
+                            debug!("Branch name could not be determined");
+                        }
+                        Ok(_) => debug!("HEAD is not pointing to a branch"),
+                        Err(err) => debug!("Failed to get HEAD: {err:#}"),
+                    },
                     Err(err) => debug!("Failed to get remote and default branch: {err:#}"),
                 },
                 Err(err) => debug!("Failed to open repository from environment: {err:#}"),
@@ -57,24 +139,42 @@ impl Shortcut {
     }
 }
 
-/// Returns the first found remote (from REMOTE_NAMES) and its default branch name
-fn get_remote_and_default_branch(repo: &Repository) -> anyhow::Result<(String, String)> {
-    for remote_name in REMOTE_NAMES {
-        if repo.find_remote(remote_name).is_ok() {
-            let clean_pattern = format!("{remote_name}/");
-            let revparse_spec = format!("{clean_pattern}HEAD");
+/// Returns the first found remote (from provided list) and its default branch name
+fn get_remote_and_default_branch<I, S>(
+    repo: &Repository,
+    remote_names: I,
+) -> anyhow::Result<(String, String)>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str> + Debug,
+{
+    for remote_name in remote_names {
+        let remote_name = remote_name.as_ref();
+        debug!("Trying remote: {remote_name:?}");
 
-            if let Ok((_, Some(reference))) = repo.revparse_ext(&revparse_spec) {
-                if let Some(ref_short) = reference.shorthand() {
-                    return Ok((
-                        remote_name.to_string(),
-                        ref_short.replace(&clean_pattern, ""),
-                    ));
+        match repo.find_remote(remote_name) {
+            Ok(_) => {
+                let clean_pattern = format!("{remote_name}/");
+                let revparse_spec = format!("{clean_pattern}HEAD");
+
+                match repo.revparse_ext(&revparse_spec) {
+                    Ok((_, Some(reference))) => {
+                        if let Some(ref_short) = reference.shorthand() {
+                            return Ok((
+                                remote_name.to_string(),
+                                ref_short.replace(&clean_pattern, ""),
+                            ));
+                        }
+
+                        debug!("Reference shorthand is None for remote {remote_name:?}");
+                    }
+                    Ok((_, None)) => debug!("No reference found for spec {revparse_spec}"),
+                    Err(err) => debug!("Failed to rev-parse {revparse_spec}: {err:#}"),
                 }
             }
+            Err(err) => debug!("Remote {remote_name:?} not found: {err:#}"),
         }
     }
 
-    // No matching remote and HEAD found
     bail!("Could not find remote and default branch")
 }

--- a/src/af/lib.rs
+++ b/src/af/lib.rs
@@ -88,9 +88,15 @@ pub enum Applet {
     },
 
     /// Short aliases for common command combinations (e.g. gcmff)
-    #[command(subcommand)]
     #[command(version)]
-    Shortcuts(Shortcut),
+    Shortcuts {
+        #[command(subcommand)]
+        shortcut: Shortcut,
+
+        /// Increase output verbosity (-v, -vv, -vvv, etc.)
+        #[command(flatten)]
+        verbose: clap_verbosity_flag::Verbosity,
+    },
 }
 
 impl Applet {
@@ -99,7 +105,7 @@ impl Applet {
             Applet::Dot { verbose, .. } => verbose.log_level_filter(),
             Applet::Git { verbose, .. } => verbose.log_level_filter(),
             Applet::ProjectGitClone { verbose, .. } => verbose.log_level_filter(),
-            Applet::Shortcuts(_) => LevelFilter::Off,
+            Applet::Shortcuts { verbose, .. } => verbose.log_level_filter(),
             _ => DEFAULT_LOG_LEVEL,
         }
     }
@@ -115,7 +121,7 @@ impl Applet {
 
             Applet::Git { git, .. } => git.run(&multi).await,
 
-            Applet::Shortcuts(shortcut) => {
+            Applet::Shortcuts { shortcut, .. } => {
                 shortcut.run();
                 Ok(())
             },


### PR DESCRIPTION
Introduced `gp` abbreviation that expands to a `git push` command. Supports choosing remote priority and flags: `--no-verify`, `--force-with-lease`, `--force`.
Updated `Applet::Shortcuts` to accept verbosity options.