### PR TITLE
fix(shortcuts): reorder GitPushRemote variants and default to origin

### DIFF
--- a/docs/af.md
+++ b/docs/af.md
@@ -201,9 +201,9 @@ Expands to: git push <remote> <branch> \[optional flags\]
 
 - `-r`, `--remote <REMOTE_PRIORITY>` — Remote priority strategy when pushing (e.g., upstream first, origin first)
 
-  Default value: `origin-first`
+  Default value: `origin`
 
-  Possible values: `origin-first`, `origin`, `upstream-first`, `upstream`
+  Possible values: `origin`, `origin-first`, `upstream`, `upstream-first`
 
 - `-n`, `--no-verify` — Push with –no-verify flag (skip pre-push hooks)
 

--- a/src/af/cmd/shortcuts/abbreviations/mod.rs
+++ b/src/af/cmd/shortcuts/abbreviations/mod.rs
@@ -13,10 +13,10 @@ const ORIGIN_UPSTREAM: &[&str] = &["origin", "upstream"];
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum GitPushRemote {
     #[default]
-    OriginFirst,
     Origin,
-    UpstreamFirst,
+    OriginFirst,
     Upstream,
+    UpstreamFirst,
 }
 
 impl IntoIterator for GitPushRemote {


### PR DESCRIPTION
Set `origin` as the default value instead of `origin-first` as usually you don't expect to push to upstream if origin doesn't exist.