### PR TITLE
feat(shortcuts): add gd abbreviation for git diff with optional pbcopy

### DIFF
--- a/docs/af.md
+++ b/docs/af.md
@@ -15,6 +15,7 @@ This document contains the help content for the `af` command-line program.
 - [`af shortcuts abbreviations`↴](#af-shortcuts-abbreviations)
 - [`af shortcuts abbreviations gcmff`↴](#af-shortcuts-abbreviations-gcmff)
 - [`af shortcuts abbreviations gp`↴](#af-shortcuts-abbreviations-gp)
+- [`af shortcuts abbreviations gd`↴](#af-shortcuts-abbreviations-gd)
 
 ## `af`
 
@@ -184,6 +185,7 @@ Group of abbreviation subcommands (alias: a, abbr, abbreviation)
 
 - `gcmff` — Expands to: git checkout <default-branch> && git fetch <remote> && git merge –ff-only <remote>/<default-branch>
 - `gp` — Expands to: git push <remote> <branch> \[optional flags\]
+- `gd` — Expands to: git diff <reference> – <files> \[optionally copy to clipboard\]
 
 ## `af shortcuts abbreviations gcmff`
 
@@ -210,3 +212,15 @@ Expands to: git push <remote> <branch> \[optional flags\]
 - `-f`, `--force-with-lease` — Push with –force-with-lease flag (safe force push)
 
 - `-F`, `--force` — Push with –force flag (unsafe force push, overrides remote)
+
+## `af shortcuts abbreviations gd`
+
+Expands to: git diff <reference> – <files> \[optionally copy to clipboard\]
+
+**Usage:** `af shortcuts abbreviations gd [OPTIONS]`
+
+###### **Options:**
+
+- `-f`, `--files <FILES>` — Specific files to diff (if omitted, diffs all changes)
+- `-r`, `--reference <REFERENCE>` — Git reference to diff against (e.g. HEAD)
+- `-p`, `--pbcopy` — Copy the diff output to clipboard using pbcopy

--- a/src/af/consts.rs
+++ b/src/af/consts.rs
@@ -25,8 +25,10 @@ pub const WEBSTORM: &str = "webstorm";
 // Commands
 pub const WHICH: &str = "which";
 pub const GIT: &str = "git";
+pub const PBCOPY: &str = "pbcopy";
 
 // Git specific
+pub const HEAD: &str = "HEAD";
 pub const ORIGIN: &str = "origin";
 pub const UPSTREAM: &str = "upstream";
 pub const ORIGIN_SLICE: &[&str] = &[ORIGIN];
@@ -37,6 +39,7 @@ pub const PUSH: &str = "push";
 pub const FETCH: &str = "fetch";
 pub const MERGE: &str = "merge";
 pub const CHECKOUT: &str = "checkout";
+pub const DIFF: &str = "diff";
 pub const NO_VERIFY: &str = "--no-verify";
 pub const FORCE_WITH_LEASE: &str = "--force-with-lease";
 pub const FF_ONLY: &str = "--ff-only";


### PR DESCRIPTION
Added `gd` subcommand to `shortcuts abbreviations` for diffing changes and optionally copying output to clipboard.