### PR TITLE
feat(browser): add cross-platform browser discovery and launch support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,15 +31,18 @@ dependencies = [
  "dialoguer",
  "fern",
  "git2",
+ "glob",
  "humantime",
  "indicatif",
  "indicatif-log-bridge",
  "log",
  "octocrab",
  "phf",
+ "rayon",
  "regex",
  "thiserror 2.0.12",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -414,6 +417,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +740,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -1562,6 +1596,26 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,18 @@ console = "0.15.11"
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 fern = { version = "0.7.1", features = ["colored"] }
 git2 = "0.20.0"
+glob = "0.3.2"
 humantime = "2.1.0"
 indicatif = "0.17.11"
 indicatif-log-bridge = "0.2.3"
 log = "0.4.26"
 octocrab = "0.44.0"
 phf = { version = "0.11.3", features = ["macros"] }
+rayon = "1.10.0"
 regex = "1.11.1"
 thiserror = "2.0.12"
 tokio = { version = "1.44.0", features = ["rt", "rt-multi-thread", "macros"] }
+url = "2.5.4"
 
 [package]
 name = "af"
@@ -48,15 +51,18 @@ console.workspace = true
 dialoguer.workspace = true
 fern.workspace = true
 git2.workspace = true
+glob.workspace = true
 humantime.workspace = true
 indicatif.workspace = true
 indicatif-log-bridge.workspace = true
 log.workspace = true
 octocrab.workspace = true
 phf.workspace = true
+rayon.workspace = true
 regex.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+url.workspace = true
 
 [lib]
 name = "af"

--- a/docs/af.md
+++ b/docs/af.md
@@ -16,6 +16,9 @@ This document contains the help content for the `af` command-line program.
 - [`af shortcuts abbreviations gcmff`↴](#af-shortcuts-abbreviations-gcmff)
 - [`af shortcuts abbreviations gp`↴](#af-shortcuts-abbreviations-gp)
 - [`af shortcuts abbreviations gd`↴](#af-shortcuts-abbreviations-gd)
+- [`af browser`↴](#af-browser)
+- [`af browser open`↴](#af-browser-open)
+- [`af browser find`↴](#af-browser-find)
 
 ## `af`
 
@@ -28,6 +31,7 @@ This document contains the help content for the `af` command-line program.
 - `git` — Git-related helper commands
 - `pgc` — Shortcut for `af git clone-project`
 - `shortcuts` — Short aliases for common command combinations (e.g. gcmff)
+- `browser` — Open and inspect installed browsers
 
 ## `af completions`
 
@@ -224,3 +228,61 @@ Expands to: git diff <reference> – <files> \[optionally copy to clipboard\]
 - `-f`, `--files <FILES>` — Specific files to diff (if omitted, diffs all changes)
 - `-r`, `--reference <REFERENCE>` — Git reference to diff against (e.g. HEAD)
 - `-p`, `--pbcopy` — Copy the diff output to clipboard using pbcopy
+
+## `af browser`
+
+Open and inspect installed browsers
+
+**Usage:** `af browser [OPTIONS] <COMMAND>`
+
+###### **Subcommands:**
+
+- `open` — Group of browser subcommands (alias: b)
+- `find` — Find installed browsers (alias: f)
+
+###### **Options:**
+
+- `-v`, `--verbose` — Increase logging verbosity
+- `-q`, `--quiet` — Decrease logging verbosity
+
+## `af browser open`
+
+Group of browser subcommands (alias: b)
+
+**Usage:** `af browser open [OPTIONS] <URL>`
+
+###### **Arguments:**
+
+- `<URL>` — The URL to open (must be a valid absolute URL)
+
+###### **Options:**
+
+- `--new-tab <NEW_TAB>` — Open each URL in a new tab (default: true)
+
+  Default value: `true`
+
+  Possible values: `true`, `false`
+
+- `-b`, `--browser <BROWSER>` — Browser to use for opening the URL
+
+  Default value: `firefox`
+
+  Possible values: `brave`, `chrome`, `edge`, `firefox`, `opera`
+
+## `af browser find`
+
+Find installed browsers (alias: f)
+
+**Usage:** `af browser find [OPTIONS]`
+
+###### **Options:**
+
+- `-k`, `--kind <BROWSER>` — Filter results by browser kinds (comma-separated)
+
+  Default values: `brave`, `chrome`, `edge`, `firefox`, `opera`
+
+  Possible values: `brave`, `chrome`, `edge`, `firefox`, `opera`
+
+- `-a`, `--all` — Show all matching results (not just the first one per kind)
+
+- `-p`, `--path` — Display only the full paths to executables

--- a/src/af/cmd/browser/mod.rs
+++ b/src/af/cmd/browser/mod.rs
@@ -1,0 +1,112 @@
+mod structures;
+
+use crate::cmd::browser::structures::Kind;
+use crate::consts::{DEFAULT_HOMEBREW_PREFIX, FLAG_NEW_TAB, FLAG_URL, HOMEBREW_PREFIX};
+
+use anyhow::bail;
+use clap::Subcommand;
+use std::{
+    env,
+    process::{Command, Stdio},
+};
+use url::Url;
+
+#[derive(Debug, Subcommand)]
+pub enum Browser {
+    /// Group of browser subcommands (alias: b)
+    #[command(visible_aliases = ["o"])]
+    Open {
+        /// Open each URL in a new tab (default: true)
+        #[arg(long, default_value_t = true, require_equals = true)]
+        new_tab: std::primitive::bool,
+
+        /// Browser to use for opening the URL
+        #[arg(
+            long,
+            short,
+            value_enum,
+            value_name = "BROWSER",
+            default_value_t = Kind::Firefox,
+        )]
+        browser: Kind,
+
+        /// The URL to open (must be a valid absolute URL)
+        url: Url,
+    },
+
+    /// Find installed browsers (alias: f)
+    #[command(visible_aliases = ["f"])]
+    Find {
+        /// Filter results by browser kinds (comma-separated)
+        #[arg(
+            long = "kind",
+            short,
+            value_enum,
+            value_name = "BROWSER",
+            value_delimiter = ',',
+            default_values_t = Kind::all(),
+        )]
+        kinds: Vec<Kind>,
+
+        /// Show all matching results (not just the first one per kind)
+        #[arg(long, short)]
+        all: bool,
+
+        /// Display only the full paths to executables
+        #[arg(long, short)]
+        path: bool,
+    },
+}
+
+impl Browser {
+    pub fn run(&self) -> anyhow::Result<()> {
+        let dirs = vec![
+            env::var(HOMEBREW_PREFIX)
+                .unwrap_or(DEFAULT_HOMEBREW_PREFIX.to_string())
+                .into(),
+            "/Applications".into(),
+        ];
+
+        match self {
+            Self::Open {
+                new_tab,
+                browser,
+                url,
+            } => {
+                if !cfg!(target_os = "macos") {
+                    bail!("This subcommand is not supported on non-macOS systems");
+                }
+
+                let mut args = vec![FLAG_URL, url.as_str()];
+
+                if *new_tab {
+                    args.insert(0, FLAG_NEW_TAB);
+                }
+
+                let browser = structures::find_browser(&dirs, *browser)?;
+
+                Command::new(browser.path())
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .args(&args)
+                    .spawn()?;
+
+                Ok(())
+            }
+            Browser::Find { kinds, all, path } => {
+                let browsers = structures::find_browsers(&dirs, kinds, *all);
+
+                for b in browsers {
+                    if *path {
+                        println!("{}", b.path().display());
+                    } else {
+                        println!("{b}");
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/af/cmd/browser/structures.rs
+++ b/src/af/cmd/browser/structures.rs
@@ -1,0 +1,354 @@
+use crate::consts::{BREW, FLAG_PREFIX, FLAG_VERSION};
+use Kind::*;
+
+use anyhow::{anyhow, bail};
+use clap::ValueEnum;
+use glob::glob;
+use log::{debug, trace};
+use rayon::prelude::*;
+use std::{
+    collections::BTreeMap,
+    ffi::OsStr,
+    fmt,
+    fmt::{Display, Formatter},
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Kind {
+    Brave,
+    Chrome,
+    Edge,
+    Firefox,
+    Opera,
+}
+
+impl Display for Kind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.short_name())
+    }
+}
+
+struct BrowserPath(Kind, PathBuf);
+
+impl From<(Kind, PathBuf)> for BrowserPath {
+    fn from(value: (Kind, PathBuf)) -> Self {
+        let (kind, path) = value;
+        Self(kind, path)
+    }
+}
+
+impl Kind {
+    pub fn all() -> Vec<Kind> {
+        Self::value_variants().to_vec()
+    }
+
+    fn with_path(path: PathBuf) -> Option<BrowserPath> {
+        path.file_name()
+            .and_then(OsStr::to_str)
+            .and_then(Self::from_bin)
+            .map(|kind| BrowserPath(kind, path.to_owned()))
+    }
+
+    fn bin(&self) -> &str {
+        match self {
+            Chrome => "Google Chrome",
+            Edge => "Microsoft Edge",
+            Brave => "Brave Browser",
+            Opera => "Opera",
+            Firefox => "firefox",
+        }
+    }
+
+    fn from_bin(bin: &str) -> Option<Kind> {
+        Kind::value_variants()
+            .iter()
+            .cloned()
+            .find(|&k| k.bin() == bin)
+    }
+
+    fn app(&self) -> &str {
+        match self {
+            Chrome => "Google Chrome.app",
+            Edge => "Microsoft Edge.app",
+            Brave => "Brave Browser.app",
+            Opera => "Opera.app",
+            Firefox => "Firefox.app",
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Chrome => "Google Chrome",
+            Edge => "Microsoft Edge",
+            Brave => "Brave Browser",
+            Opera => "Opera",
+            Firefox => "Mozilla Firefox",
+        }
+    }
+
+    fn short_name(&self) -> &str {
+        match self {
+            Chrome => "Chrome",
+            Edge => "Edge",
+            Brave => "Brave",
+            Opera => "Opera",
+            Firefox => "Firefox",
+        }
+    }
+
+    fn applications_path(&self) -> PathBuf {
+        Path::new("/Applications")
+            .join(self.app())
+            .join("Contents/MacOS")
+            .join(self.bin())
+    }
+
+    fn parse_version(&self, version: &str) -> anyhow::Result<(String, String)> {
+        let version = version.trim();
+        let name = self.name().to_string();
+
+        if self == &Opera {
+            return Ok((name, version.to_string()));
+        }
+
+        version
+            .strip_prefix(&name)
+            .map(str::trim)
+            .map(|v| (name, v.to_string()))
+            .ok_or(anyhow!("invalid version: {version}"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Browser {
+    name: String,
+    kind: Kind,
+    path: PathBuf,
+    version: String,
+}
+
+impl Display for Browser {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:<name_max$} {:<version_max$} {}",
+            self.name,
+            self.version,
+            self.path.display(),
+            name_max = Kind::value_variants()
+                .iter()
+                .map(Kind::name)
+                .map(str::len)
+                .max()
+                .unwrap_or_default(),
+            version_max = 13,
+        )
+    }
+}
+
+impl Browser {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn version(&self) -> String {
+        format!("{} {}", self.name, self.version)
+    }
+}
+
+/// Entry point to find all known browser executables
+pub fn find_browsers(extra_dirs: &[PathBuf], kinds: &[Kind], all: bool) -> Vec<Browser> {
+    let mut all_kind_paths = vec![];
+
+    // 1. Hardcoded .app locations
+    all_kind_paths.extend(find_in_known_locations(kinds));
+
+    // 2. Homebrew
+    if let Some(homebrew_prefix) = detect_homebrew_prefix() {
+        all_kind_paths.extend(find_in_homebrew(&homebrew_prefix, kinds));
+    }
+
+    // 3. Extra user-provided dirs
+    all_kind_paths.extend(find_in_custom_dirs(extra_dirs, kinds));
+
+    // Deduplicate by <binary> --version
+    let mut seen_unique = BTreeMap::new();
+    let mut seen_all = BTreeMap::new();
+
+    for BrowserPath(kind, path) in all_kind_paths {
+        match get_browser(&kind, &path) {
+            Ok(browser) => {
+                // insert returns None if the key was not already present
+                if seen_unique
+                    .insert(browser.version(), browser.clone())
+                    .is_none()
+                {
+                    debug!("Found browser: {:#?}", browser);
+                }
+
+                seen_all.insert(format!("{browser}"), browser.clone());
+            }
+            Err(err) => debug!("{} {FLAG_VERSION} error: {err}", path.display()),
+        }
+    }
+
+    let result = match all {
+        true => seen_all,
+        false => seen_unique,
+    };
+
+    result.values().cloned().collect()
+}
+
+pub fn find_browser(extra_dirs: &[PathBuf], kind: Kind) -> anyhow::Result<Browser> {
+    match find_browsers(extra_dirs, &[kind], false).first() {
+        Some(b) => Ok(b.clone()),
+        None => bail!("No browser found for {}", kind),
+    }
+}
+
+/// Helper to extract a normalized version string from `--version` output
+fn get_browser(kind: &Kind, path: &Path) -> anyhow::Result<Browser> {
+    Command::new(path)
+        .arg(FLAG_VERSION)
+        .output()
+        .map_err(|e| anyhow!(e))
+        .and_then(|output| {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            trace!(
+                "{} --version: (stdout: {}) (stderr: {})",
+                path.display(),
+                stdout.trim(),
+                stderr.trim(),
+            );
+
+            if output.status.success() {
+                let (name, version) = kind.parse_version(stdout.trim())?;
+                return Ok(Browser {
+                    name,
+                    version,
+                    kind: *kind,
+                    path: path.to_path_buf(),
+                });
+            }
+
+            bail!("non-zero exit code: {}", output.status.code().unwrap_or(-1));
+        })
+}
+
+/// Look in `/Applications/...` for known browser `.app` bundles
+fn find_in_known_locations(kinds: &[Kind]) -> Vec<BrowserPath> {
+    kinds
+        .par_iter()
+        .cloned()
+        .filter(|kind| kind.applications_path().exists())
+        .map(|kind| (kind, kind.applications_path()).into())
+        .collect()
+}
+
+/// Use `brew --prefix` to detect Homebrew installation
+fn detect_homebrew_prefix() -> Option<PathBuf> {
+    Command::new(BREW)
+        .arg(FLAG_PREFIX)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| PathBuf::from(s.trim()))
+}
+
+/// Look under `$(brew --prefix)/bin` and `Caskroom` for known browser executables
+fn find_in_homebrew(prefix: &Path, kinds: &[Kind]) -> Vec<BrowserPath> {
+    let bin_dir = prefix.join("bin");
+    let caskroom_dir = prefix.join("Caskroom");
+
+    let bin_matches = find_executables_in_dir(&bin_dir);
+    let cask_matches = scan_caskroom(&caskroom_dir, kinds);
+
+    bin_matches.into_iter().chain(cask_matches).collect()
+}
+
+/// Search Caskroom for any known browsers
+fn scan_caskroom(caskroom: &Path, kinds: &[Kind]) -> Vec<BrowserPath> {
+    if !caskroom.is_dir() {
+        return Vec::new();
+    }
+
+    fs::read_dir(caskroom)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let entry_name = entry.file_name().to_string_lossy().to_lowercase();
+
+            kinds.iter().cloned().find_map(|kind| {
+                if !entry_name.contains(kind.bin()) {
+                    return None;
+                }
+
+                let pattern = entry
+                    .path()
+                    .join("latest")
+                    .join("*.app/Contents/MacOS")
+                    .join(kind.bin());
+
+                glob(pattern.to_string_lossy().as_ref())
+                    .ok()?
+                    .flatten()
+                    .next()
+                    .map(|p| (kind, p).into())
+            })
+        })
+        .collect()
+}
+
+/// Search user-provided directories for `.app/Contents/MacOS/<bin>`
+fn find_in_custom_dirs(dirs: &[PathBuf], kinds: &[Kind]) -> Vec<BrowserPath> {
+    dirs.par_iter()
+        .flat_map(|base| {
+            fs::read_dir(base)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .filter_map(|entry| {
+                    let path = entry.path();
+                    let is_app = path.extension().and_then(|e| e.to_str()) == Some("app");
+
+                    if !is_app {
+                        return None;
+                    }
+
+                    for kind in kinds {
+                        let exec = path.join("Contents/MacOS").join(kind.bin());
+                        if exec.exists() {
+                            return Some(BrowserPath(*kind, exec));
+                        }
+                    }
+
+                    None
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+/// Find exact executable names in a flat directory
+fn find_executables_in_dir(dir: &Path) -> Vec<BrowserPath> {
+    if !dir.is_dir() {
+        return vec![];
+    }
+
+    fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file())
+        .filter_map(Kind::with_path)
+        .collect()
+}

--- a/src/af/cmd/mod.rs
+++ b/src/af/cmd/mod.rs
@@ -1,3 +1,4 @@
 pub mod dot;
 pub mod git;
 pub mod shortcuts;
+pub mod browser;

--- a/src/af/consts.rs
+++ b/src/af/consts.rs
@@ -6,6 +6,7 @@ pub const AF: &str = "af";
 // Env vars
 pub const XPC_SERVICE_NAME: &str = "XPC_SERVICE_NAME";
 pub const HOME: &str = "HOME";
+pub const HOMEBREW_PREFIX: &str = "HOMEBREW_PREFIX";
 
 // Languages
 pub const C: &str = "c";
@@ -26,6 +27,13 @@ pub const WEBSTORM: &str = "webstorm";
 pub const WHICH: &str = "which";
 pub const GIT: &str = "git";
 pub const PBCOPY: &str = "pbcopy";
+pub const BREW: &str = "brew";
+
+// Flags
+pub const FLAG_VERSION: &str = "--version";
+pub const FLAG_PREFIX: &str = "--prefix";
+pub const FLAG_URL: &str = "--url";
+pub const FLAG_NEW_TAB: &str = "--new-tab";
 
 // Git specific
 pub const HEAD: &str = "HEAD";
@@ -56,3 +64,6 @@ pub const MUTED_TEAL: Color = Color::TrueColor {
     g: 195,
     b: 170,
 };
+
+// Misc
+pub const DEFAULT_HOMEBREW_PREFIX: &str = "/opt/homebrew";


### PR DESCRIPTION
- Add `af browser find` to list installed browsers (supports filtering and path-only output)
- Add `af browser open` to open URLs in selected browsers
- Support major macOS browsers: Chrome, Firefox, Brave, Edge, Opera
- Detect browsers from system locations, Homebrew, and user-specified paths
- Normalize browser versions from `--version` output and deduplicate
- Added new dependencies: `rayon`, `glob`, and `url` for fast and flexible discovery